### PR TITLE
Handle HTTP 401 when token expires

### DIFF
--- a/welkin/authentication.py
+++ b/welkin/authentication.py
@@ -1,6 +1,5 @@
 import logging
 import shelve
-from functools import cached_property
 
 import requests
 from requests import HTTPError
@@ -36,12 +35,13 @@ class WelkinAuth(HTTPBasicAuth):
         r.headers["Authorization"] = f"Bearer {self.token}"
         return r
 
-    def obtain_token(self):
+    def obtain_token(self, refresh=False):
         with shelve.open("welkin") as db:
-            try:
-                return db[self.tenant]["token"]
-            except KeyError:
-                pass
+            if not refresh:
+                try:
+                    return db[self.tenant]["token"]
+                except KeyError:
+                    pass
 
             response = requests.post(
                 f"https://api.live.welkincloud.io/{self.tenant}/admin/api_clients/{self.api_client}",


### PR DESCRIPTION
Adds a `refresh` option to token fetch mechanism and uses that mechanism on HTTP 401 responses with "TOKEN_EXPIRED" in the response body.