### PR TITLE
Bug/clean date

### DIFF
--- a/test/cassettes/test_patient_create_birthdate.yaml
+++ b/test/cassettes/test_patient_create_birthdate.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: '{"firstName": "happy", "lastName": "borf", "birthDate": "2022-08-09T00:00:00.000Z"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_38a40ec6-98bc-4b47-86b9-7d83d0937577
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '83'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-welkin/0.0.4
+    method: POST
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients
+  response:
+    body:
+      string: '{"id": "35e28b21-80c2-4563-8961-75c9306b574b", "externalGuid": null,
+        "externalId": null, "mrn": null, "nric": null, "createdAt": "2022-08-09T22:54:13.368Z",
+        "updatedAt": "2022-08-09T22:54:13.368Z", "createdBy": "createdBy_REDACTED_9cf25126-07c2-4a95-8a16-c8610d3156f1",
+        "updatedBy": "updatedBy_REDACTED_6529353c-8792-4072-9a7d-4e94de1e87ea", "createdByName":
+        "createdByName_REDACTED_52a2cc86-b3a2-4f77-bf3f-9a81c79d1f29", "updatedByName":
+        "updatedByName_REDACTED_57d0c04f-c47f-4c28-b1ba-455aa3efff19", "firstName":
+        "happy", "lastName": "borf", "middleName": null, "birthDate": "2022-08-09T00:00:00.000Z",
+        "gender": "UNKNOWN", "maritalStatus": "UKN", "primaryLanguage": "ENGLISH",
+        "secondaryLanguage": null, "email": null, "secondaryEmail": null, "phone":
+        null, "primaryPhoneCapabilities": [], "secondaryPhone": null, "secondaryPhoneCapabilities":
+        [], "country": null, "state": null, "city": null, "zip": null, "addressLine1":
+        null, "addressLine2": null, "timezone": null, "patientTerritories": [], "careTeamMembers":
+        [], "patientPrograms": [], "careTeam": [], "cadence": [], "patientRegion":
+        null, "patientRegionTitle": null, "patientTerritory": null, "pointOfContact":
+        null}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Aug 2022 22:54:13 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=yVSMsXnqD6/P3kXSmmxZCvXzVNTvMexIHuZAgjKQjnMvX5UbW2K1QT/zs6Xbzdu96YzvBeBZwWHXrVorArjQCTulYNpH54A9eowDq2cfgIKd9bSRdL12ULF14zD0;
+        Expires=Tue, 16 Aug 2022 22:54:13 GMT; Path=/
+      - AWSALBCORS=yVSMsXnqD6/P3kXSmmxZCvXzVNTvMexIHuZAgjKQjnMvX5UbW2K1QT/zs6Xbzdu96YzvBeBZwWHXrVorArjQCTulYNpH54A9eowDq2cfgIKd9bSRdL12ULF14zD0;
+        Expires=Tue, 16 Aug 2022 22:54:13 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: ''
+version: 1

--- a/test/test_patients.py
+++ b/test/test_patients.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 
 from welkin.exceptions import WelkinHTTPError
@@ -7,6 +9,17 @@ from welkin.models.patient import Patient, Patients
 @pytest.mark.vcr()
 def test_patient_create(client, vcr_cassette):
     patient = client.Patient(firstName="Foo", lastName="Bar").create()
+
+    assert isinstance(patient, Patient)
+    assert hasattr(patient, "id")
+    assert len(vcr_cassette) == 1
+
+
+@pytest.mark.vcr()
+def test_patient_create_birthdate(client, vcr_cassette):
+    patient = client.Patient(
+        firstName="happy", lastName="borf", birthDate=date.today()
+    ).create()
 
     assert isinstance(patient, Patient)
     assert hasattr(patient, "id")

--- a/welkin/client.py
+++ b/welkin/client.py
@@ -179,6 +179,7 @@ class Client(Session):
                     msg = response.json()
                     codes = ["NOT_VALID_JSON_WEB_TOKEN", "TOKEN_EXPIRED"]
                     if any(i.get("errorCode") in codes for i in msg):
+                        breakpoint()
                         self.auth.refresh_token()
                         continue
 

--- a/welkin/client.py
+++ b/welkin/client.py
@@ -179,7 +179,6 @@ class Client(Session):
                     msg = response.json()
                     codes = ["NOT_VALID_JSON_WEB_TOKEN", "TOKEN_EXPIRED"]
                     if any(i.get("errorCode") in codes for i in msg):
-                        breakpoint()
                         self.auth.refresh_token()
                         continue
 

--- a/welkin/util.py
+++ b/welkin/util.py
@@ -46,7 +46,9 @@ def clean_request_params(params: dict) -> dict:
 
 
 def clean_date(date: date) -> str:
-    return date.strftime("%Y-%m-%dT00:00:00.000Z")
+    dt = datetime(date.year, date.month, date.day, 0, 0, 0)
+
+    return clean_datetime(dt)
 
 
 def clean_datetime(dt: datetime) -> str:

--- a/welkin/util.py
+++ b/welkin/util.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 # NOTE: `clean_request_payload` and `clean_request_params` are intentionally DRY
 # violations. The code may be the same, but they represent different knowledge.
@@ -9,6 +9,8 @@ def clean_request_payload(payload: dict) -> dict:
     for k, v in payload.items():
         if isinstance(v, datetime):
             payload[k] = clean_datetime(v)
+        elif isinstance(v, date):
+            payload[k] = clean_date(v)
         elif isinstance(v, dict):
             payload[k] = clean_request_payload(v)
         elif isinstance(v, list):
@@ -21,6 +23,8 @@ def clean_json_list(data: list) -> list:
     for ind, item in enumerate(data):
         if isinstance(item, datetime):
             data[ind] = clean_datetime(item)
+        elif isinstance(item, date):
+            data[ind] = clean_date(item)
         elif isinstance(item, dict):
             data[ind] = clean_request_payload(item)
         elif isinstance(item, list):
@@ -33,10 +37,16 @@ def clean_request_params(params: dict) -> dict:
     for k, v in params.items():
         if isinstance(v, datetime):
             params[k] = clean_datetime(v)
+        elif isinstance(v, date):
+            params[k] = clean_date(v)
         elif isinstance(v, list):
             params[k] = ",".join(v)
 
     return params
+
+
+def clean_date(date: date) -> str:
+    return date.strftime("%Y-%m-%dT00:00:00.000Z")
 
 
 def clean_datetime(dt: datetime) -> str:


### PR DESCRIPTION
This pr adds a clean date method specifically for the creation of patients with their birthdate but also general use. The clean datetime does not suffice and passing a raw date does not work with the api.

Example of failure: 
<img width="1038" alt="Screen Shot 2022-08-09 at 6 56 58 PM" src="https://user-images.githubusercontent.com/31940792/183775826-0ca6ec8b-ca87-48a8-b012-a5103c059c5a.png">

Expected behavior is for the date to be converted into a string and the patient successfully created 

