### PR TITLE
Feature/care plan

### DIFF
--- a/test/cassettes/test_care_plan_create.yaml
+++ b/test/cassettes/test_care_plan_create.yaml
@@ -1,0 +1,64 @@
+interactions:
+- request:
+    body: '{"overview": "This is a message for the overview."}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_6a722dc7-06b5-485b-a631-c6e0e3772497
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-welkin/0.0.4
+    method: POST
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan/overview
+  response:
+    body:
+      string: '{"createdByName": "createdByName_REDACTED_eb3db9fb-f8a0-451e-8e9d-62a25bce2143",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_0798d9d1-7dbd-424d-ab80-90e3ddeff6a3",
+        "updatedAt": "2022-08-08T20:20:48.802Z", "overview": "This is a message for
+        the overview."}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Aug 2022 20:20:48 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=dD2kQwaro/doVsN7TaWTVUQT2eRC93gKkAimwua7jAFHV6/EoO5Mcph1rlc101A58IuV1ZOB9NfrKg/hvW59Kd9uAkq9BxafnVnIi0CD1B8MEY1N0v8wObDiJyFg;
+        Expires=Mon, 15 Aug 2022 20:20:48 GMT; Path=/
+      - AWSALBCORS=dD2kQwaro/doVsN7TaWTVUQT2eRC93gKkAimwua7jAFHV6/EoO5Mcph1rlc101A58IuV1ZOB9NfrKg/hvW59Kd9uAkq9BxafnVnIi0CD1B8MEY1N0v8wObDiJyFg;
+        Expires=Mon, 15 Aug 2022 20:20:48 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/test/cassettes/test_care_plan_create_passing_patient_id.yaml
+++ b/test/cassettes/test_care_plan_create_passing_patient_id.yaml
@@ -1,0 +1,64 @@
+interactions:
+- request:
+    body: '{"overview": "This is a message for the overview."}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_fa8ed4bb-7a6c-4d6c-ad28-e9fb3edd5a33
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '51'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-welkin/0.0.5
+    method: POST
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/331678c1-0ec9-4e4a-a947-8147a1d067a5/care-plan/overview
+  response:
+    body:
+      string: '{"createdByName": "createdByName_REDACTED_9e8fa9d3-ac4d-41d2-8142-02626878aeb1",
+        "createdAt": "2022-08-11T23:36:09.918Z", "updatedByName": "updatedByName_REDACTED_77eca2b8-e967-4f81-80d4-73b777ccc067",
+        "updatedAt": "2022-08-11T23:36:09.918Z", "overview": "This is a message for
+        the overview."}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 11 Aug 2022 23:36:09 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=DN2rU/BO2m/KTsE7019n1cl/iehPYYFpA4YBzWEzFNIG3kQyOiyzYe4Ft8tj70g/NgTPHwgGkJXk+BI9CnFfWKo3972qZE3MJ8reiTpCBIRW+3D3QDPRkgMz11oW;
+        Expires=Thu, 18 Aug 2022 23:36:09 GMT; Path=/
+      - AWSALBCORS=DN2rU/BO2m/KTsE7019n1cl/iehPYYFpA4YBzWEzFNIG3kQyOiyzYe4Ft8tj70g/NgTPHwgGkJXk+BI9CnFfWKo3972qZE3MJ8reiTpCBIRW+3D3QDPRkgMz11oW;
+        Expires=Thu, 18 Aug 2022 23:36:09 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/test/cassettes/test_care_plan_read.yaml
+++ b/test/cassettes/test_care_plan_read.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_f4cdd35c-4f90-46a3-90f4-18d0ea1a8a1f
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-welkin/0.0.4
+    method: GET
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan
+  response:
+    body:
+      string: '{"id": "059846c0-2eae-4126-acfd-57bd27042a95", "createdByName": "createdByName_REDACTED_d42eeebc-211f-44bd-9358-ef7db8ffb362",
+        "createdAt": "2022-08-08T17:56:36.088Z", "updatedByName": "updatedByName_REDACTED_dc6a6be6-12f7-4797-8199-31ac7fb0da7a",
+        "updatedAt": "2022-08-08T19:18:42.624Z", "patientId": "173a8adf-92e8-4832-8900-027c71b0d768",
+        "patientOverview": {"createdByName": "createdByName_REDACTED_7405a29c-6156-4840-88e5-eff5d2267274",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_b9aba97c-b1bc-46e5-b49c-c5d04decb902",
+        "updatedAt": "2022-08-08T19:18:42.623Z", "overview": "Overview message test"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Aug 2022 20:20:39 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=kJX3xsApacQsrbLld60bGFIHZ4W+aJvcuZa6kyHhYqcJ1YxmQrPk6SvQU56unrf3uKg2nMStxGsEMv0yRWjeFTT61kyiBNqOJZIKGn9CvxiR08pPTq/Yhmn7xa7F;
+        Expires=Mon, 15 Aug 2022 20:20:39 GMT; Path=/
+      - AWSALBCORS=kJX3xsApacQsrbLld60bGFIHZ4W+aJvcuZa6kyHhYqcJ1YxmQrPk6SvQU56unrf3uKg2nMStxGsEMv0yRWjeFTT61kyiBNqOJZIKGn9CvxiR08pPTq/Yhmn7xa7F;
+        Expires=Mon, 15 Aug 2022 20:20:39 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/test/cassettes/test_care_plan_read_passing_patient_id.yaml
+++ b/test/cassettes/test_care_plan_read_passing_patient_id.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_2a3afe22-be26-493c-8c05-4d067cae33a5
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-welkin/0.0.5
+    method: GET
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/331678c1-0ec9-4e4a-a947-8147a1d067a5/care-plan
+  response:
+    body:
+      string: '{"id": "3564e807-779a-412c-8b38-5db4356eafb0", "createdByName": "createdByName_REDACTED_c8593e09-2767-45c5-adff-ee25929d161f",
+        "createdAt": "2022-08-11T23:31:51.510Z", "updatedByName": "updatedByName_REDACTED_245d28af-c8ee-4a26-8705-badb4d6a1c81",
+        "updatedAt": "2022-08-11T23:36:09.918Z", "patientId": "331678c1-0ec9-4e4a-a947-8147a1d067a5",
+        "patientOverview": {"createdByName": "createdByName_REDACTED_8fc55488-d9bc-44ca-8334-38cca312f327",
+        "createdAt": "2022-08-11T23:36:09.918Z", "updatedByName": "updatedByName_REDACTED_bf3df3e3-5a26-4da0-8756-7f7762967192",
+        "updatedAt": "2022-08-11T23:36:09.918Z", "overview": "This is a message for
+        the overview."}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Aug 2022 01:14:37 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=9vUDmnPYEGpcmbEQjXIAyfZOSG7JERwishk4Is1uKiGfd8TT17blFQFc9ZIdYQ7DZVRpqiMPK1E1dFaVRV/PueX3ISoeJIrKLIEdWDxAeXEuQFd5lSkw0ABtroua;
+        Expires=Fri, 19 Aug 2022 01:14:37 GMT; Path=/
+      - AWSALBCORS=9vUDmnPYEGpcmbEQjXIAyfZOSG7JERwishk4Is1uKiGfd8TT17blFQFc9ZIdYQ7DZVRpqiMPK1E1dFaVRV/PueX3ISoeJIrKLIEdWDxAeXEuQFd5lSkw0ABtroua;
+        Expires=Fri, 19 Aug 2022 01:14:37 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/test/cassettes/test_care_plan_update.yaml
+++ b/test/cassettes/test_care_plan_update.yaml
@@ -7,22 +7,21 @@ interactions:
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - API_TOKEN_4d2f3a5c-db5a-4fc8-a8b7-c6c12efb9e4c
+      - API_TOKEN_f643ae6d-11da-4cd9-b350-a6603907e5e1
       Connection:
       - keep-alive
       User-Agent:
-      - python-welkin/0.0.4
+      - python-welkin/0.0.5
     method: GET
     uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan
   response:
     body:
-      string: '{"id": "059846c0-2eae-4126-acfd-57bd27042a95", "createdByName": "createdByName_REDACTED_d67fad6d-026a-49da-a7bc-0856798080e9",
-        "createdAt": "2022-08-08T17:56:36.088Z", "updatedByName": "updatedByName_REDACTED_42f17ff0-4009-4511-8858-ff4ac760a9f9",
-        "updatedAt": "2022-08-08T20:20:48.803Z", "patientId": "173a8adf-92e8-4832-8900-027c71b0d768",
-        "patientOverview": {"createdByName": "createdByName_REDACTED_54d21963-7c21-4bd7-bd4b-d38238365c35",
-        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_fe36fd85-a32e-4175-86aa-0e4a026ffa25",
-        "updatedAt": "2022-08-08T20:20:48.802Z", "overview": "This is a message for
-        the overview."}}'
+      string: '{"id": "059846c0-2eae-4126-acfd-57bd27042a95", "createdByName": "createdByName_REDACTED_8ccfcba2-e36a-4543-a60d-09facb0fceb8",
+        "createdAt": "2022-08-08T17:56:36.088Z", "updatedByName": "updatedByName_REDACTED_21a1d411-b432-4781-939c-eb0fd7a88829",
+        "updatedAt": "2022-08-09T16:55:29.082Z", "patientId": "173a8adf-92e8-4832-8900-027c71b0d768",
+        "patientOverview": {"createdByName": "createdByName_REDACTED_b382d34a-4172-4e93-9b43-4f037677844e",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_518ce434-a513-474e-8e4a-d9e67c72ea5b",
+        "updatedAt": "2022-08-09T16:55:29.081Z", "overview": "A new overview message."}}'
     headers:
       Access-Control-Allow-Headers:
       - authorization, content-type, xsrf-token, security-role
@@ -41,16 +40,16 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 08 Aug 2022 20:27:15 GMT
+      - Wed, 10 Aug 2022 18:40:44 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
       Set-Cookie:
-      - AWSALB=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et;
-        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/
-      - AWSALBCORS=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et;
-        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=yx5nl5zmmhQuFOMt3RV/bcrLSEeyjsDryDuuSyHrwVAj+8hWnlKUxuQRTKUACOOUAt7OjJNtgMTK3zXY6X8TDMJh7czOvBkZp0YQ++HZwRAAd7ZBcn6riNLo4UCI;
+        Expires=Wed, 17 Aug 2022 18:40:44 GMT; Path=/
+      - AWSALBCORS=yx5nl5zmmhQuFOMt3RV/bcrLSEeyjsDryDuuSyHrwVAj+8hWnlKUxuQRTKUACOOUAt7OjJNtgMTK3zXY6X8TDMJh7czOvBkZp0YQ++HZwRAAd7ZBcn6riNLo4UCI;
+        Expires=Wed, 17 Aug 2022 18:40:44 GMT; Path=/; SameSite=None; Secure
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -61,32 +60,33 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: '{"overview": "New overview message."}'
+    body: '{"overview": "A new overview message 123"}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
       Authorization:
-      - API_TOKEN_4d2f3a5c-db5a-4fc8-a8b7-c6c12efb9e4c
+      - API_TOKEN_f643ae6d-11da-4cd9-b350-a6603907e5e1
       Connection:
       - keep-alive
       Content-Length:
-      - '37'
+      - '42'
       Content-Type:
       - application/json
       Cookie:
-      - AWSALB=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et;
-        AWSALBCORS=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et
+      - AWSALB=yx5nl5zmmhQuFOMt3RV/bcrLSEeyjsDryDuuSyHrwVAj+8hWnlKUxuQRTKUACOOUAt7OjJNtgMTK3zXY6X8TDMJh7czOvBkZp0YQ++HZwRAAd7ZBcn6riNLo4UCI;
+        AWSALBCORS=yx5nl5zmmhQuFOMt3RV/bcrLSEeyjsDryDuuSyHrwVAj+8hWnlKUxuQRTKUACOOUAt7OjJNtgMTK3zXY6X8TDMJh7czOvBkZp0YQ++HZwRAAd7ZBcn6riNLo4UCI
       User-Agent:
-      - python-welkin/0.0.4
+      - python-welkin/0.0.5
     method: PUT
     uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan/overview
   response:
     body:
-      string: '{"createdByName": "createdByName_REDACTED_4924603e-2804-4d17-a1f0-c6f0e4a601c5",
-        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_bfdda14d-df49-440e-8567-0183585a0b51",
-        "updatedAt": "2022-08-08T20:27:16.013Z", "overview": "New overview message."}'
+      string: '{"createdByName": "createdByName_REDACTED_4dcbedbc-b17e-4738-b24f-29fe772841be",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_73c24174-bdd4-4fd4-88c1-b93a4a6b07ac",
+        "updatedAt": "2022-08-10T18:40:44.293Z", "overview": "A new overview message
+        123"}'
     headers:
       Access-Control-Allow-Headers:
       - authorization, content-type, xsrf-token, security-role
@@ -105,16 +105,80 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 08 Aug 2022 20:27:16 GMT
+      - Wed, 10 Aug 2022 18:40:44 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
       Set-Cookie:
-      - AWSALB=sseS1xhgVSNmNdQMAggrUWYjp5FYhIlIq6tSi0eddOwCsCVtTphKEqXY22TZeTS9xHVCiGhOzQhsqJxsjlCC7XIdDRMQS7D9tr3YB6tg/DtyypJjYgvBWi/jD6ys;
-        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/
-      - AWSALBCORS=sseS1xhgVSNmNdQMAggrUWYjp5FYhIlIq6tSi0eddOwCsCVtTphKEqXY22TZeTS9xHVCiGhOzQhsqJxsjlCC7XIdDRMQS7D9tr3YB6tg/DtyypJjYgvBWi/jD6ys;
-        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=d4lFNkEN9Yj2LetmgdH1Exi/a+5irDTSLCR7SvlGmixHWC/mR/stZQGs7UTdmzRGOIUenT267njt/ie3sTeEs3dAeAmoSOaLnV9tlymA5xavIGESv1SJkZzncKbl;
+        Expires=Wed, 17 Aug 2022 18:40:44 GMT; Path=/
+      - AWSALBCORS=d4lFNkEN9Yj2LetmgdH1Exi/a+5irDTSLCR7SvlGmixHWC/mR/stZQGs7UTdmzRGOIUenT267njt/ie3sTeEs3dAeAmoSOaLnV9tlymA5xavIGESv1SJkZzncKbl;
+        Expires=Wed, 17 Aug 2022 18:40:44 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_f643ae6d-11da-4cd9-b350-a6603907e5e1
+      Connection:
+      - keep-alive
+      Cookie:
+      - AWSALB=d4lFNkEN9Yj2LetmgdH1Exi/a+5irDTSLCR7SvlGmixHWC/mR/stZQGs7UTdmzRGOIUenT267njt/ie3sTeEs3dAeAmoSOaLnV9tlymA5xavIGESv1SJkZzncKbl;
+        AWSALBCORS=d4lFNkEN9Yj2LetmgdH1Exi/a+5irDTSLCR7SvlGmixHWC/mR/stZQGs7UTdmzRGOIUenT267njt/ie3sTeEs3dAeAmoSOaLnV9tlymA5xavIGESv1SJkZzncKbl
+      User-Agent:
+      - python-welkin/0.0.5
+    method: GET
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan
+  response:
+    body:
+      string: '{"id": "059846c0-2eae-4126-acfd-57bd27042a95", "createdByName": "createdByName_REDACTED_8b897174-60f8-432f-b880-24220f14bda7",
+        "createdAt": "2022-08-08T17:56:36.088Z", "updatedByName": "updatedByName_REDACTED_a965628f-d136-486c-8650-7c7d9b2d0b89",
+        "updatedAt": "2022-08-10T18:40:44.294Z", "patientId": "173a8adf-92e8-4832-8900-027c71b0d768",
+        "patientOverview": {"createdByName": "createdByName_REDACTED_d2a47bb2-38ba-4cc1-a9d6-49596fad37c4",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_f4ec90ee-12f4-46ac-ad72-af1ae3622e6c",
+        "updatedAt": "2022-08-10T18:40:44.293Z", "overview": "A new overview message
+        123"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 Aug 2022 18:40:44 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=OMyukRTfpLg7THuuFI/yJKCVkKlYMBxg3appqipqm6rSHI1BCZPuQBZ3YF5+gl+XfiWoZpjxujXgzEkFFwcih4ncxk+h1a4twdz0RwwpKF31BdVXSSMWrhEqxy2w;
+        Expires=Wed, 17 Aug 2022 18:40:44 GMT; Path=/
+      - AWSALBCORS=OMyukRTfpLg7THuuFI/yJKCVkKlYMBxg3appqipqm6rSHI1BCZPuQBZ3YF5+gl+XfiWoZpjxujXgzEkFFwcih4ncxk+h1a4twdz0RwwpKF31BdVXSSMWrhEqxy2w;
+        Expires=Wed, 17 Aug 2022 18:40:44 GMT; Path=/; SameSite=None; Secure
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:

--- a/test/cassettes/test_care_plan_update.yaml
+++ b/test/cassettes/test_care_plan_update.yaml
@@ -1,0 +1,127 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_4d2f3a5c-db5a-4fc8-a8b7-c6c12efb9e4c
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-welkin/0.0.4
+    method: GET
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan
+  response:
+    body:
+      string: '{"id": "059846c0-2eae-4126-acfd-57bd27042a95", "createdByName": "createdByName_REDACTED_d67fad6d-026a-49da-a7bc-0856798080e9",
+        "createdAt": "2022-08-08T17:56:36.088Z", "updatedByName": "updatedByName_REDACTED_42f17ff0-4009-4511-8858-ff4ac760a9f9",
+        "updatedAt": "2022-08-08T20:20:48.803Z", "patientId": "173a8adf-92e8-4832-8900-027c71b0d768",
+        "patientOverview": {"createdByName": "createdByName_REDACTED_54d21963-7c21-4bd7-bd4b-d38238365c35",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_fe36fd85-a32e-4175-86aa-0e4a026ffa25",
+        "updatedAt": "2022-08-08T20:20:48.802Z", "overview": "This is a message for
+        the overview."}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Aug 2022 20:27:15 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et;
+        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/
+      - AWSALBCORS=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et;
+        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"overview": "New overview message."}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_4d2f3a5c-db5a-4fc8-a8b7-c6c12efb9e4c
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/json
+      Cookie:
+      - AWSALB=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et;
+        AWSALBCORS=pFuPZ37R4+TO2g0xfcIdgydwJJQrTLZmqnpoxowwpakzGBnqIwXdWSo84XV9VR0ROirNe+wc55mTZprfR3Z/WKparaN8CaaptlhMGreeOgkfbU2tDxgHoJhq95et
+      User-Agent:
+      - python-welkin/0.0.4
+    method: PUT
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan/overview
+  response:
+    body:
+      string: '{"createdByName": "createdByName_REDACTED_4924603e-2804-4d17-a1f0-c6f0e4a601c5",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_bfdda14d-df49-440e-8567-0183585a0b51",
+        "updatedAt": "2022-08-08T20:27:16.013Z", "overview": "New overview message."}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 08 Aug 2022 20:27:16 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=sseS1xhgVSNmNdQMAggrUWYjp5FYhIlIq6tSi0eddOwCsCVtTphKEqXY22TZeTS9xHVCiGhOzQhsqJxsjlCC7XIdDRMQS7D9tr3YB6tg/DtyypJjYgvBWi/jD6ys;
+        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/
+      - AWSALBCORS=sseS1xhgVSNmNdQMAggrUWYjp5FYhIlIq6tSi0eddOwCsCVtTphKEqXY22TZeTS9xHVCiGhOzQhsqJxsjlCC7XIdDRMQS7D9tr3YB6tg/DtyypJjYgvBWi/jD6ys;
+        Expires=Mon, 15 Aug 2022 20:27:15 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/test/cassettes/test_care_plan_update_passing_patient_id.yaml
+++ b/test/cassettes/test_care_plan_update_passing_patient_id.yaml
@@ -1,0 +1,192 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_c7b4ea24-e9cc-4fc6-adf2-cbbe554868a4
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-welkin/0.0.5
+    method: GET
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan
+  response:
+    body:
+      string: '{"id": "059846c0-2eae-4126-acfd-57bd27042a95", "createdByName": "createdByName_REDACTED_21855277-0c1e-4a0f-8d33-34afc52de718",
+        "createdAt": "2022-08-08T17:56:36.088Z", "updatedByName": "updatedByName_REDACTED_78dd3bfb-eb49-4863-97ae-0ae12d3f70c0",
+        "updatedAt": "2022-08-12T00:46:01.620Z", "patientId": "173a8adf-92e8-4832-8900-027c71b0d768",
+        "patientOverview": {"createdByName": "createdByName_REDACTED_3d92c900-c75d-4f49-ba02-1184c8d19681",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_9e4cdf2b-d490-4a59-ba71-299bc68147a5",
+        "updatedAt": "2022-08-12T00:46:01.619Z", "overview": "This is a new overview
+        message for a test"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Aug 2022 00:47:52 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=4JlLO35ybkVokW0xDWXC8GuJ6zmZrn46fGqiIZBvTCLfBcuNLK4owv98GcVn5tE09kS58p+sEvNmE9Ef4SwQsleo615JXg6JIIh0bL1YajSOqpd/kU807HkFuvfb;
+        Expires=Fri, 19 Aug 2022 00:47:52 GMT; Path=/
+      - AWSALBCORS=4JlLO35ybkVokW0xDWXC8GuJ6zmZrn46fGqiIZBvTCLfBcuNLK4owv98GcVn5tE09kS58p+sEvNmE9Ef4SwQsleo615JXg6JIIh0bL1YajSOqpd/kU807HkFuvfb;
+        Expires=Fri, 19 Aug 2022 00:47:52 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"overview": "Why not have a new overview message?"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_c7b4ea24-e9cc-4fc6-adf2-cbbe554868a4
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json
+      Cookie:
+      - AWSALB=4JlLO35ybkVokW0xDWXC8GuJ6zmZrn46fGqiIZBvTCLfBcuNLK4owv98GcVn5tE09kS58p+sEvNmE9Ef4SwQsleo615JXg6JIIh0bL1YajSOqpd/kU807HkFuvfb;
+        AWSALBCORS=4JlLO35ybkVokW0xDWXC8GuJ6zmZrn46fGqiIZBvTCLfBcuNLK4owv98GcVn5tE09kS58p+sEvNmE9Ef4SwQsleo615JXg6JIIh0bL1YajSOqpd/kU807HkFuvfb
+      User-Agent:
+      - python-welkin/0.0.5
+    method: PUT
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan/overview
+  response:
+    body:
+      string: '{"createdByName": "createdByName_REDACTED_f229ea81-3d13-4aea-9c8e-13a69ee6eb12",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_a891b7a0-2a7d-47e0-8bc9-4214b2fba90c",
+        "updatedAt": "2022-08-12T00:47:52.342Z", "overview": "Why not have a new overview
+        message?"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Aug 2022 00:47:52 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=JNfJM/E+1xJQ5DHeK84EwCQPy+wJaYwYdWgjQO8NTdHDV7wEN8NJQFykNpiG1PhIxgk5IbnECWBXzyehogbphOgmHIR57BIdW1r0z4lXez8csWzscuEARuYR5BRS;
+        Expires=Fri, 19 Aug 2022 00:47:52 GMT; Path=/
+      - AWSALBCORS=JNfJM/E+1xJQ5DHeK84EwCQPy+wJaYwYdWgjQO8NTdHDV7wEN8NJQFykNpiG1PhIxgk5IbnECWBXzyehogbphOgmHIR57BIdW1r0z4lXez8csWzscuEARuYR5BRS;
+        Expires=Fri, 19 Aug 2022 00:47:52 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - API_TOKEN_c7b4ea24-e9cc-4fc6-adf2-cbbe554868a4
+      Connection:
+      - keep-alive
+      Cookie:
+      - AWSALB=JNfJM/E+1xJQ5DHeK84EwCQPy+wJaYwYdWgjQO8NTdHDV7wEN8NJQFykNpiG1PhIxgk5IbnECWBXzyehogbphOgmHIR57BIdW1r0z4lXez8csWzscuEARuYR5BRS;
+        AWSALBCORS=JNfJM/E+1xJQ5DHeK84EwCQPy+wJaYwYdWgjQO8NTdHDV7wEN8NJQFykNpiG1PhIxgk5IbnECWBXzyehogbphOgmHIR57BIdW1r0z4lXez8csWzscuEARuYR5BRS
+      User-Agent:
+      - python-welkin/0.0.5
+    method: GET
+    uri: https://api.live.welkincloud.io/tenant_REDACTED/instance_REDACTED/patients/173a8adf-92e8-4832-8900-027c71b0d768/care-plan
+  response:
+    body:
+      string: '{"id": "059846c0-2eae-4126-acfd-57bd27042a95", "createdByName": "createdByName_REDACTED_68390acb-a307-4e41-959f-59119075ad80",
+        "createdAt": "2022-08-08T17:56:36.088Z", "updatedByName": "updatedByName_REDACTED_61e2939e-56b5-4ab3-8406-7e07969525de",
+        "updatedAt": "2022-08-12T00:47:52.342Z", "patientId": "173a8adf-92e8-4832-8900-027c71b0d768",
+        "patientOverview": {"createdByName": "createdByName_REDACTED_b35068be-9813-434b-9b57-5276d7d06db7",
+        "createdAt": "2022-08-08T19:18:42.623Z", "updatedByName": "updatedByName_REDACTED_21cd3c82-a446-498c-8e1f-e74bff252774",
+        "updatedAt": "2022-08-12T00:47:52.342Z", "overview": "Why not have a new overview
+        message?"}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, content-type, xsrf-token, security-role
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, PATCH, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - xsrf-token
+      Access-Control-Max-Age:
+      - '3600'
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 12 Aug 2022 00:47:52 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - AWSALB=PLrHLNESmL6DBL0w69UElb00s4T8e3kpeAU+jAJTakmCzyhl0Yf8+M9ByWH1+Eo6isyrQu+Ko5RW8+SYj9fhUFQ2j/erz56f9Q3OqoBLQOAA5sWEH5j48x7ciu4o;
+        Expires=Fri, 19 Aug 2022 00:47:52 GMT; Path=/
+      - AWSALBCORS=PLrHLNESmL6DBL0w69UElb00s4T8e3kpeAU+jAJTakmCzyhl0Yf8+M9ByWH1+Eo6isyrQu+Ko5RW8+SYj9fhUFQ2j/erz56f9Q3OqoBLQOAA5sWEH5j48x7ciu4o;
+        Expires=Fri, 19 Aug 2022 00:47:52 GMT; Path=/; SameSite=None; Secure
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/test/test_care_plan.py
+++ b/test/test_care_plan.py
@@ -1,0 +1,39 @@
+import pytest
+
+from welkin.models import CarePlan
+
+
+@pytest.mark.vcr()
+def test_care_plan_create(client, vcr_cassette):
+    patient = client.Patient(id="173a8adf-92e8-4832-8900-027c71b0d768")
+
+    overview_message = "This is a message for the overview."
+
+    care_plan = patient.CarePlan(overview=overview_message)
+
+    created_cp = care_plan.create()
+
+    assert isinstance(created_cp, CarePlan)
+    assert len(vcr_cassette) == 1
+
+
+@pytest.mark.vcr()
+def test_care_plan_read(client, vcr_cassette):
+    patient = client.Patient(id="173a8adf-92e8-4832-8900-027c71b0d768")
+    care_plan = patient.CarePlan().get()
+
+    assert isinstance(care_plan, CarePlan)
+    assert care_plan.id
+    assert len(vcr_cassette) == 1
+
+
+@pytest.mark.vcr()
+def test_care_plan_update(client, vcr_cassette):
+    patient = client.Patient(id="173a8adf-92e8-4832-8900-027c71b0d768")
+    care_plan = patient.CarePlan().get()
+    overview = care_plan.patientOverview["overview"]
+
+    care_plan.update(overview="New overview message.")
+
+    assert care_plan.overview != overview
+    assert len(vcr_cassette) == 2

--- a/test/test_care_plan.py
+++ b/test/test_care_plan.py
@@ -32,8 +32,10 @@ def test_care_plan_update(client, vcr_cassette):
     patient = client.Patient(id="173a8adf-92e8-4832-8900-027c71b0d768")
     care_plan = patient.CarePlan().get()
     overview = care_plan.patientOverview["overview"]
+    new_overview = "A new overview message 123"
+    care_plan.CarePlanOverview(**{"overview": new_overview}).update()
+    care_plan = patient.CarePlan().get()
 
-    care_plan.update(overview="New overview message.")
-
-    assert care_plan.overview != overview
-    assert len(vcr_cassette) == 2
+    assert care_plan.patientOverview["overview"] != overview
+    assert care_plan.patientOverview["overview"] == new_overview
+    assert len(vcr_cassette) == 3

--- a/test/test_care_plan.py
+++ b/test/test_care_plan.py
@@ -18,9 +18,30 @@ def test_care_plan_create(client, vcr_cassette):
 
 
 @pytest.mark.vcr()
+def test_care_plan_create_passing_patient_id(client, vcr_cassette):
+    patient_id = "331678c1-0ec9-4e4a-a947-8147a1d067a5"
+    overview_message = "This is a message for the overview."
+
+    care_plan = client.CarePlan(overview=overview_message).create(patient_id=patient_id)
+
+    assert isinstance(care_plan, CarePlan)
+    assert len(vcr_cassette) == 1
+
+
+@pytest.mark.vcr()
 def test_care_plan_read(client, vcr_cassette):
     patient = client.Patient(id="173a8adf-92e8-4832-8900-027c71b0d768")
     care_plan = patient.CarePlan().get()
+
+    assert isinstance(care_plan, CarePlan)
+    assert care_plan.id
+    assert len(vcr_cassette) == 1
+
+
+@pytest.mark.vcr()
+def test_care_plan_read_passing_patient_id(client, vcr_cassette):
+    patient_id = "331678c1-0ec9-4e4a-a947-8147a1d067a5"
+    care_plan = client.CarePlan().get(patient_id=patient_id)
 
     assert isinstance(care_plan, CarePlan)
     assert care_plan.id
@@ -35,6 +56,22 @@ def test_care_plan_update(client, vcr_cassette):
     new_overview = "A new overview message 123"
     care_plan.CarePlanOverview(**{"overview": new_overview}).update()
     care_plan = patient.CarePlan().get()
+
+    assert care_plan.patientOverview["overview"] != overview
+    assert care_plan.patientOverview["overview"] == new_overview
+    assert len(vcr_cassette) == 3
+
+
+@pytest.mark.vcr()
+def test_care_plan_update_passing_patient_id(client, vcr_cassette):
+    patient_id = "173a8adf-92e8-4832-8900-027c71b0d768"
+    care_plan = client.CarePlan().get(patient_id=patient_id)
+    overview = care_plan.patientOverview["overview"]
+    new_overview = "Why not have a new overview message?"
+    care_plan = client.CarePlanOverview(**{"overview": new_overview}).update(
+        patient_id=patient_id
+    )
+    care_plan = client.CarePlan().get(patient_id=patient_id)
 
     assert care_plan.patientOverview["overview"] != overview
     assert care_plan.patientOverview["overview"] == new_overview

--- a/welkin/models/__init__.py
+++ b/welkin/models/__init__.py
@@ -6,6 +6,7 @@ from welkin.models.assessment import (
     Assessments,
 )
 from welkin.models.calendar import CalendarEvent, CalendarEvents, Schedules
+from welkin.models.care_plan import CarePlan
 from welkin.models.cdt import CDT, CDTs
 from welkin.models.chat import Chat, Chats, SearchChats
 from welkin.models.encounter import Disposition, Encounter, Encounters
@@ -22,6 +23,7 @@ __all__ = [
     "Assessments",
     "CalendarEvent",
     "CalendarEvents",
+    "CarePlan",
     "CDT",
     "CDTs",
     "Chat",

--- a/welkin/models/__init__.py
+++ b/welkin/models/__init__.py
@@ -6,7 +6,7 @@ from welkin.models.assessment import (
     Assessments,
 )
 from welkin.models.calendar import CalendarEvent, CalendarEvents, Schedules
-from welkin.models.care_plan import CarePlan
+from welkin.models.care_plan import CarePlan, CarePlanOverview
 from welkin.models.cdt import CDT, CDTs
 from welkin.models.chat import Chat, Chats, SearchChats
 from welkin.models.encounter import Disposition, Encounter, Encounters
@@ -24,6 +24,7 @@ __all__ = [
     "CalendarEvent",
     "CalendarEvents",
     "CarePlan",
+    "CarePlanOverview",
     "CDT",
     "CDTs",
     "Chat",

--- a/welkin/models/base.py
+++ b/welkin/models/base.py
@@ -94,18 +94,6 @@ class Resource(dict, SchemaBase):
 
         return self
 
-    def patch_as_put(self, resource, data, *args, **kwargs):
-        response = self._client.put(
-            resource,
-            json=data,
-            *args,
-            **kwargs,
-        )
-
-        super().update(response)
-
-        return self
-
     def delete(self, resource, *args, **kwargs):
         response = self._client.delete(resource, *args, **kwargs)
         super().update(response)

--- a/welkin/models/base.py
+++ b/welkin/models/base.py
@@ -82,10 +82,10 @@ class Resource(dict, SchemaBase):
 
         return self
 
-    def put(self, resource, *args, **kwargs):
+    def put(self, resource, data, *args, **kwargs):
         response = self._client.put(
             resource,
-            json=self,
+            json=data,
             *args,
             **kwargs,
         )

--- a/welkin/models/base.py
+++ b/welkin/models/base.py
@@ -82,7 +82,19 @@ class Resource(dict, SchemaBase):
 
         return self
 
-    def put(self, resource, data, *args, **kwargs):
+    def put(self, resource, *args, **kwargs):
+        response = self._client.put(
+            resource,
+            json=self,
+            *args,
+            **kwargs,
+        )
+
+        super().update(response)
+
+        return self
+
+    def patch_as_put(self, resource, data, *args, **kwargs):
         response = self._client.put(
             resource,
             json=data,

--- a/welkin/models/care_plan.py
+++ b/welkin/models/care_plan.py
@@ -1,0 +1,20 @@
+from welkin.models.base import Collection, Resource
+from welkin.pagination import MetaInfoIterator
+
+
+class CarePlan(Resource):
+    def create(self):
+        return super().post(
+            f"{self._client.instance}/patients/{self._parent.id}/care-plan/overview"
+        )
+
+    def get(self):
+        return super().get(
+            f"{self._client.instance}/patients/{self._parent.id}/care-plan"
+        )
+
+    def update(self, **kwargs):
+        return super().put(
+            f"{self._client.instance}/patients/{self._parent.id}/care-plan/overview",
+            kwargs,
+        )

--- a/welkin/models/care_plan.py
+++ b/welkin/models/care_plan.py
@@ -1,22 +1,31 @@
 from welkin.models.base import Resource
+from welkin.models.util import find_patient_id_in_parents
 
 
 class CarePlanOverview(Resource):
-    def update(self):
+    def update(self, patient_id: str = None):
+        if not patient_id:
+            # self._parent -> CarePlan
+            # CarePlan._parent -> Patient
+            patient_id = find_patient_id_in_parents(self)
         return super().put(
-            f"{self._client.instance}/patients/{self._parent._parent.id}/care-plan/overview"
+            f"{self._client.instance}/patients/{patient_id}/care-plan/overview"
         )
 
 
 class CarePlan(Resource):
     subresources = [CarePlanOverview]
 
-    def create(self):
+    def create(self, patient_id: str = None):
+        if not patient_id:
+            # self._parent -> Patient
+            patient_id = find_patient_id_in_parents(self)
         return super().post(
-            f"{self._client.instance}/patients/{self._parent.id}/care-plan/overview"
+            f"{self._client.instance}/patients/{patient_id}/care-plan/overview"
         )
 
-    def get(self):
-        return super().get(
-            f"{self._client.instance}/patients/{self._parent.id}/care-plan"
-        )
+    def get(self, patient_id: str = None):
+        if not patient_id:
+            # self._parent -> Patient
+            patient_id = find_patient_id_in_parents(self)
+        return super().get(f"{self._client.instance}/patients/{patient_id}/care-plan")

--- a/welkin/models/care_plan.py
+++ b/welkin/models/care_plan.py
@@ -14,7 +14,7 @@ class CarePlan(Resource):
         )
 
     def update(self, **kwargs):
-        return super().put(
+        return super().patch_as_put(
             f"{self._client.instance}/patients/{self._parent.id}/care-plan/overview",
             kwargs,
         )

--- a/welkin/models/care_plan.py
+++ b/welkin/models/care_plan.py
@@ -1,8 +1,16 @@
-from welkin.models.base import Collection, Resource
-from welkin.pagination import MetaInfoIterator
+from welkin.models.base import Resource
+
+
+class CarePlanOverview(Resource):
+    def update(self):
+        return super().put(
+            f"{self._client.instance}/patients/{self._parent._parent.id}/care-plan/overview"
+        )
 
 
 class CarePlan(Resource):
+    subresources = [CarePlanOverview]
+
     def create(self):
         return super().post(
             f"{self._client.instance}/patients/{self._parent.id}/care-plan/overview"
@@ -11,10 +19,4 @@ class CarePlan(Resource):
     def get(self):
         return super().get(
             f"{self._client.instance}/patients/{self._parent.id}/care-plan"
-        )
-
-    def update(self, **kwargs):
-        return super().patch_as_put(
-            f"{self._client.instance}/patients/{self._parent.id}/care-plan/overview",
-            kwargs,
         )

--- a/welkin/models/patient.py
+++ b/welkin/models/patient.py
@@ -1,5 +1,6 @@
 from welkin.models.assessment import AssessmentRecord, AssessmentRecords
 from welkin.models.base import Collection, Resource
+from welkin.models.care_plan import CarePlan
 from welkin.models.cdt import CDT, CDTs
 from welkin.models.chat import Chat, Chats, SearchChats
 from welkin.models.encounter import Encounter, Encounters
@@ -10,6 +11,7 @@ class Patient(Resource):
     subresources = [
         AssessmentRecord,
         AssessmentRecords,
+        CarePlan,
         CDT,
         CDTs,
         Chat,

--- a/welkin/models/util.py
+++ b/welkin/models/util.py
@@ -9,13 +9,12 @@ def find_patient_id_in_parents(model_instance):
         return model_instance.id
     elif hasattr(model_instance, "patientId"):
         return model_instance.patientId
+    elif model_instance._parent:
+        return find_patient_id_in_parents(model_instance._parent)
     else:
-        try:
-            return find_patient_id_in_parents(model_instance._parent)
-        except AttributeError:
-            raise Exception(
-                f"Cannot find patient id. Model._parent chain ends in {model_instance}"
-            )
+        raise Exception(
+            f"Cannot find patient id. Model._parent chain ends in {model_instance}"
+        )
 
 
 class EncounterSubResource:

--- a/welkin/models/util.py
+++ b/welkin/models/util.py
@@ -1,6 +1,23 @@
 from sys import modules
 
 
+def find_patient_id_in_parents(model_instance):
+    if isinstance(
+        model_instance,
+        getattr(modules["welkin.models"], "Patient"),
+    ):
+        return model_instance.id
+    elif hasattr(model_instance, "patientId"):
+        return model_instance.patientId
+    else:
+        try:
+            return find_patient_id_in_parents(model_instance._parent)
+        except AttributeError:
+            raise Exception(
+                f"Cannot find patient id. Model._parent chain ends in {model_instance}"
+            )
+
+
 class EncounterSubResource:
     """Utility class for subresources of Encounters to get patient and encounter ids"""
 


### PR DESCRIPTION
Adding `CarePlan` model with tests.

Updating was a bit of an issue since the endpoint is `PUT` but will only accept the key `"overview"` which is found in `CarePlan.patientOverview["overview"]` from the `GET` response.

Implemented update via subresource pattern established by `Assessments` to resolve this.

The subresource `Goal` and it's subresources will be implemented in a future PR.