### PR TITLE
Reset file offsets before sending a request

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -14,7 +14,7 @@ from welkin.util import (
     clean_request_params,
     clean_request_payload,
     find_model_id,
-    rewind_files,
+    reset_file_offsets,
     to_camel_case,
     to_snake_case,
 )
@@ -98,7 +98,7 @@ class TestCleanRequestParams:
         assert cleaned["list"] == "foo,bar,baz"
 
 
-class TestRewindFiles:
+class TestResetFileOffsets:
     @pytest.fixture
     def file(self) -> BytesIO:
         file = BytesIO(b"foo\nbar\nbaz")
@@ -135,10 +135,10 @@ class TestRewindFiles:
             "POST", "https://example.com", files=request.getfixturevalue(request.param)
         )
 
-    def test_rewind_files(self, file, mock_request: Request):
+    def test_reset_file_offsets(self, file, mock_request: Request):
         assert file.tell() == 1
 
-        rewind_files(mock_request.files)
+        reset_file_offsets(mock_request.files)
         assert file.tell() == 0
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import copy
 import sys
+from io import BytesIO
 
 import pytest
+from requests import Request
 
 from welkin.util import (
     clean_date,
@@ -12,6 +14,7 @@ from welkin.util import (
     clean_request_params,
     clean_request_payload,
     find_model_id,
+    rewind_files,
     to_camel_case,
     to_snake_case,
 )
@@ -93,6 +96,50 @@ class TestCleanRequestParams:
         assert cleaned["datetime"] == pst_datetime_str
         assert cleaned["date"] == base_date_str
         assert cleaned["list"] == "foo,bar,baz"
+
+
+class TestRewindFiles:
+    @pytest.fixture
+    def file(self) -> BytesIO:
+        file = BytesIO(b"foo\nbar\nbaz")
+        file.seek(1)
+
+        return file
+
+    @pytest.fixture
+    def file_info(self, file):
+        return {"files": file}
+
+    @pytest.fixture
+    def file_info_with_name(self, file: BytesIO):
+        return [("files", ("file.txt", file))]
+
+    @pytest.fixture
+    def file_info_with_content_type(self, file: BytesIO):
+        return [("files", ("file.txt", file, "text/plain"))]
+
+    @pytest.fixture
+    def file_info_with_content_type_and_headers(self, file: BytesIO):
+        return [("files", ("file.txt", file, "text/plain", {"Expires": "0"}))]
+
+    @pytest.fixture(
+        params=[
+            "file_info",
+            "file_info_with_name",
+            "file_info_with_content_type",
+            "file_info_with_content_type_and_headers",
+        ]
+    )
+    def mock_request(self, request: pytest.FixtureRequest) -> Request:
+        return Request(
+            "POST", "https://example.com", files=request.getfixturevalue(request.param)
+        )
+
+    def test_rewind_files(self, file, mock_request: Request):
+        assert file.tell() == 1
+
+        rewind_files(mock_request.files)
+        assert file.tell() == 0
 
 
 def test_clean_date(base_date, base_date_str):

--- a/welkin/client.py
+++ b/welkin/client.py
@@ -17,7 +17,12 @@ from requests.packages.urllib3.util.retry import Retry  # type: ignore
 from welkin import __version__, models
 from welkin.authentication import WelkinAuth
 from welkin.exceptions import WelkinHTTPError
-from welkin.util import _build_resources, clean_request_params, clean_request_payload
+from welkin.util import (
+    _build_resources,
+    clean_request_params,
+    clean_request_payload,
+    rewind_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +177,8 @@ class Client(Session):
             request.json = clean_request_payload(request.json)
         if request.params:
             request.params = clean_request_params(request.params)
+        if request.files:
+            rewind_files(request.files)
 
         return super().prepare_request(request)
 

--- a/welkin/client.py
+++ b/welkin/client.py
@@ -21,7 +21,7 @@ from welkin.util import (
     _build_resources,
     clean_request_params,
     clean_request_payload,
-    rewind_files,
+    reset_file_offsets,
 )
 
 logger = logging.getLogger(__name__)
@@ -178,7 +178,7 @@ class Client(Session):
         if request.params:
             request.params = clean_request_params(request.params)
         if request.files:
-            rewind_files(request.files)
+            reset_file_offsets(request.files)
 
         return super().prepare_request(request)
 

--- a/welkin/util.py
+++ b/welkin/util.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from uuid import UUID
 
 import inflection
+from requests.utils import to_key_val_list
 
 from welkin.models.base import Collection, Resource, SchemaBase
 
@@ -178,6 +179,31 @@ def model_id(*models: tuple[str]) -> Callable:
         return wrapper
 
     return decorator
+
+
+def rewind_files(files: list) -> None:
+    """Rewind file-like objects to the beginning.
+
+    Args:
+        files (list): The list of files from the request.
+    """
+    file_info_with_name = 2
+    file_info_with_content_type = 3
+
+    # Similar to requests.models.RequestEncodingMixin._encode_files
+    for _, file_info in to_key_val_list(files):
+        if isinstance(file_info, (tuple, list)):
+            if len(file_info) == file_info_with_name:
+                fn, fp = file_info
+            elif len(file_info) == file_info_with_content_type:
+                fn, fp, ft = file_info
+            else:
+                fn, fp, ft, fh = file_info
+        else:
+            fp = file_info
+
+        if hasattr(fp, "seek"):
+            fp.seek(0)
 
 
 @lru_cache(maxsize=None)

--- a/welkin/util.py
+++ b/welkin/util.py
@@ -181,8 +181,8 @@ def model_id(*models: tuple[str]) -> Callable:
     return decorator
 
 
-def rewind_files(files: list) -> None:
-    """Rewind file-like objects to the beginning.
+def reset_file_offsets(files: list) -> None:
+    """Reset file-like objects to the beginning of the file.
 
     Args:
         files (list): The list of files from the request.


### PR DESCRIPTION
With our request retry mechanism on HTTP 401 responses, the follow-up request that contains files to be uploaded will fail because the file has already been read by Requests to determine the file size.

This patch ensures that all files passed into a request are at offset 0 before sending the request.